### PR TITLE
Update chips for the last round results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Caches
+__pycache__/
+
+# Virtual envs
+venv/
+
+# Jupyter notebooks
+.ipynb_checkpoints
+
+# IDEs
+.idea/

--- a/log_processor.py
+++ b/log_processor.py
@@ -71,6 +71,10 @@ class Evening:
         self.rounds.append(new_round)
         return new_round
 
+    def handle_last_round(self):
+        self._update_amounts()
+        self._record_amounts()
+
     def _record_amounts(self):
         for player, amt in self.players.items():
             self.historical_amounts[player].append((len(self.rounds), amt))
@@ -239,6 +243,7 @@ class Parser:
             except Exception as e:
                 print(row)
                 raise e
+        self.evening.handle_last_round()
         evening = self.evening
         self.evening = None
         return evening


### PR DESCRIPTION
This allows to show the final results on the plot, otherwise the last round is just omitted since the `evening.historical_amounts()` does not contain the information about the final results.

Also added a simple `.gitignore` file to ignore IDE files, virtual envs and caches.